### PR TITLE
Added types of status duplication

### DIFF
--- a/SMNC/Assets/Prefabs/Abilities/StunShot.asset
+++ b/SMNC/Assets/Prefabs/Abilities/StunShot.asset
@@ -15,4 +15,4 @@ MonoBehaviour:
   title: StunShot
   projectile: {fileID: 6814662285158218356, guid: 88e7e4d439ed172499e723fb1eea857a, type: 3}
   effect: {fileID: 11400000, guid: 66413967b565ee047b1ec6c53b7d1d44, type: 2}
-  duration: 10
+  duration: 5

--- a/SMNC/Assets/Scripts/Status Effects/StatusEffect.cs
+++ b/SMNC/Assets/Scripts/Status Effects/StatusEffect.cs
@@ -5,8 +5,12 @@ using UnityEngine;
 public abstract class StatusEffect : ScriptableObject
 {
     public string statusName;
-    public float tickRate; // How often is During() called?
+    public DuplicateHandling duplicateType = DuplicateHandling.Ignore; // How to handle the same effect being applied multiple times.
+    public float tickRate; // How often is During() called in seconds? -1 for disabled
     public virtual void StartEffect(GameObject tar) {} // Called on the first tick.
     public virtual void DuringEffect(GameObject tar) {} // Called after the first and before the last.
     public virtual void EndEffect(GameObject tar) {} // Called when the effect ends.
+
+    // Ignore, do nothing when reapplied. Stack applies more instances to the object. Extends extends the duration if longer than the current one.
+    public enum DuplicateHandling{Ignore, Stack, Extend} 
 }

--- a/SMNC/Assets/Scripts/Status Effects/StunStatus.asset
+++ b/SMNC/Assets/Scripts/Status Effects/StunStatus.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: StunStatus
   m_EditorClassIdentifier: 
   statusName: Stun
-  duration: 30
-  tickRate: 5
+  duplicateType: 2
+  tickRate: -1


### PR DESCRIPTION
When handling duplicates it can either: Not apply, Stack with existing, or extend if the duration is longer.